### PR TITLE
Merge staging: close calendar day modal after event add

### DIFF
--- a/web/frontend/src/pages/CalendarPage.tsx
+++ b/web/frontend/src/pages/CalendarPage.tsx
@@ -364,6 +364,8 @@ export function CalendarPage() {
     })
     setNewRecurrence('')
     setNewEventAllDay(false)
+    setSelectedDay(null)
+    setEditingEvent(null)
     invalidateCache('calendar', 'home', ...(selectedCalendarId ? [`calendar-${selectedCalendarId}`] : []))
   }
 


### PR DESCRIPTION
## Summary
- bring the staging fix for closing the month day modal after event creation into `main`

## Verification on staging
- npm run build
- npm run test:e2e -- calendar.spec.ts -g "creates an all-day event from the calendar UI"

## Notes
- the fix is already deployed to `staging` in commit `0273f36`.